### PR TITLE
bugfix single domain redirect

### DIFF
--- a/core/components/xrouting/elements/plugins/xrouting.plugin.php
+++ b/core/components/xrouting/elements/plugins/xrouting.plugin.php
@@ -118,6 +118,11 @@ switch ($modx->event->name) {
                 }
             }
 
+            // find matching hosts without ckey
+            if (!empty($matched_contexts) && empty($matches)) {
+                $matches[] = $matched_contexts[0];
+            }
+
         // modify request for the matched context
             if (!empty($matches)) {
                 


### PR DESCRIPTION
I came across of this problem with the following domains:

domain | context
----|----
jens.de | web (default)
jens.de/de/ | web
jens.eu | en
jens.eu/en/ | en

The Domain jens.eu redirects to the default `web` context, but have to redirect to `en` in this situation. So i think the problem is a missing match. For my project this solution solved it.